### PR TITLE
Add contributor workflow and optimize Rust expressions

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -27,8 +27,10 @@ jobs:
       - name: Set up Rust
         run: rustup show
       - uses: mozilla-actions/sccache-action@v0.0.3
-      - run: make .venv
-      - run: make pre-commit
+      - run: make sync
+      - run: make fmt
+      - run: git diff --exit-code
+      - run: make lint
       - run: make install
       - run: make test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# Contributor Guide
+
+This guide gives contributors the minimum project context needed to work on `polars-h3`. Keep changes small, use the existing patterns, and verify the Rust extension from Python before calling work done.
+
+## Project Structure
+
+- `src/`: Rust implementation of the Polars plugin expressions.
+- `src/engine/`: H3 operation modules grouped by feature area, such as indexing, traversal, metrics, hierarchy, edges, and inspection.
+- `polars_h3/`: Python package and public user-facing wrappers.
+- `polars_h3/core/`: Python functions that expose the Rust expressions through Polars.
+- `tests/`: Python test suite for the public package behavior.
+- `benchmarks/`: Benchmark helpers for comparing performance.
+- `docs/`: MkDocs documentation source.
+- `notebooks/`: Examples and exploratory notebooks.
+- `Cargo.toml`, `Cargo.lock`: Rust package metadata and locked Rust dependencies.
+- `pyproject.toml`, `uv.lock`: Python package metadata and locked Python dependencies.
+- `Makefile`: Common local development commands.
+
+## Development Workflow
+
+Use `uv` for Python commands and `make` for common repo tasks.
+
+```bash
+make sync
+make install
+make test
+```
+
+Run `make install` after changing Rust code so the local Python environment uses the rebuilt extension.
+
+For optimized builds and benchmarks:
+
+```bash
+make install-release
+make bench
+```
+
+For docs:
+
+```bash
+make docs
+```
+
+## Checks
+
+Before finishing code or build configuration changes, run the relevant checks:
+
+```bash
+make fmt
+make lint
+make test
+```
+
+For a broader local pass:
+
+```bash
+make check
+```
+
+`make check` formats, lints, rebuilds the extension in development mode, and runs the test suite.
+
+## ExecPlans
+
+Use an ExecPlan for work that is multi-step, spans several files, adds a feature, performs a refactor, or is likely to take more than about an hour. Small fixes and documentation-only updates do not need one.
+
+When an ExecPlan is useful, create or update a plan using the rules in `PLANS.md`. The plan should be self-contained enough that another contributor can pick it up later, and it should stay current as work progresses.
+
+At minimum, a plan should explain:
+
+- What user-visible behavior or maintenance outcome the work should produce.
+- Which files or modules are likely to change.
+- The concrete commands used to validate the work.
+- Progress, surprises, decisions, and final outcome.
+
+If a change affects public Python APIs, documented behavior, package metadata, or release/build behavior, call that out in the plan before implementing the change.
+
+## Coding Guidelines
+
+- Prefer existing module boundaries. Add indexing behavior under `src/engine/indexing.rs` and `polars_h3/core/indexing.py`, traversal behavior under the traversal modules, and so on.
+- Keep Rust expression names, Python wrapper names, and tests aligned by feature area.
+- Add or update tests in `tests/` when behavior changes.
+- Keep Python APIs simple and Polars-native. Public functions should accept column expressions or column names in the same style as the existing wrappers.
+- Avoid unrelated refactors while changing feature code.
+- Do not edit generated or build output such as `target/`, cache directories, or notebook checkpoint files.
+
+## Pull Request Expectations
+
+- Summarize what changed and why.
+- Mention user-facing behavior changes.
+- Include the checks you ran, especially `make test` or `make check`.
+- Keep commits focused and use concise imperative commit messages.

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,47 @@
-SHELL=/bin/bash
-PYTHON = python
-VENV_DIR = .venv
-PIP = $(VENV_DIR)/bin/pip
+.PHONY: help sync install install-release fmt lint test check docs bench clean
 
-.venv:
-	$(PYTHON) -m venv $(VENV_DIR)
-	$(PIP) install -U pip setuptools wheel
-	$(PIP) install maturin polars ruff mypy pytest
+help:
+	@echo "Targets:"
+	@echo "  sync             Install dev dependencies"
+	@echo "  install          Build/install extension in dev mode"
+	@echo "  install-release  Build/install optimized extension"
+	@echo "  fmt              Format Rust and Python"
+	@echo "  lint             Run Rust/Python checks"
+	@echo "  test             Run Python tests"
+	@echo "  check            Run fmt, lint, install, and test"
+	@echo "  docs             Serve docs locally"
+	@echo "  bench            Run benchmarks after release build"
+	@echo "  clean            Remove build artifacts"
+
+sync:
+	uv sync --all-groups
 
 install:
-	unset CONDA_PREFIX && \
-	source .venv/bin/activate && maturin develop
+	uv run maturin develop --uv
 
 install-release:
-	unset CONDA_PREFIX && \
-	source .venv/bin/activate && maturin develop --release
+	uv run maturin develop --release --uv
 
-pre-commit:
-	cargo fmt --all && cargo clippy --all-features
-	.venv/bin/python -m ruff format polars_h3 tests
+fmt:
+	cargo fmt --all
+	uv run ruff format polars_h3 tests benchmarks
+
+lint:
+	cargo clippy --all-features
+	uv run ruff check polars_h3 tests benchmarks
+	uv run mypy polars_h3
 
 test:
-	.venv/bin/python -m pytest tests
+	uv run pytest tests
 
-run: install
-	source .venv/bin/activate && python run.py
+check: fmt lint install test
 
-run-release: install-release
-	source .venv/bin/activate && python run.py
+docs:
+	uv run mkdocs serve
 
+bench: install-release
+	uv run -m benchmarks.engine
+
+clean:
+	cargo clean
+	rm -rf .pytest_cache .ruff_cache .mypy_cache

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,100 @@
+# Codex Execution Plans (ExecPlans)
+
+This file defines how to write and maintain an ExecPlan: a self-contained, living specification that a novice can follow to deliver observable, working behavior in this repository.
+
+## When to Use an ExecPlan
+- Required for multi-step or multi-file work, new features, refactors, or tasks expected to take more than about an hour.
+- Optional for trivial fixes (typos, small docs), but if you skip it for a substantial task, state the reason in your response.
+
+## How to Use This File
+- Authoring: read this file end to end before drafting; start from the skeleton; embed all context (paths, commands, definitions) so no external docs are needed.
+- Implementing: move directly to the next milestone without asking for next steps; keep the living sections current at every stopping point.
+- Discussing: record decisions and rationale inside the plan so work can be resumed later using only the ExecPlan.
+
+## Non-Negotiable Requirements
+- Self-contained and beginner-friendly: define every term; include needed repo knowledge; avoid assuming prior plans or external links.
+- Living document: revise Progress, Surprises & Discoveries, Decision Log, and Outcomes & Retrospective as work proceeds while keeping the plan self-contained.
+- Outcome-focused: describe what the user can do after the change and how to see it working; the plan must lead to demonstrably working behavior, not just code edits.
+- Explicit acceptance: state behaviors, commands, and observable outputs that prove success.
+
+## Formatting Rules
+- Default envelope is a single fenced code block labeled `md`; do not nest other triple backticks inside—indent commands, transcripts, and diffs instead.
+- If the file contains only the ExecPlan, omit the enclosing code fence.
+- Use blank lines after headings; prefer prose over lists. Checklists are permitted only in the Progress section (and are mandatory there).
+
+## Guidelines
+- Define jargon immediately and tie it to concrete files or commands in this repo.
+- Anchor on outcomes: acceptance should be phrased as observable behavior; for internal changes, show tests or scenarios that demonstrate the effect.
+- Specify repository context explicitly: full paths, functions, modules, working directory for commands, and environment assumptions.
+- Be idempotent and safe: describe retries or rollbacks for risky steps; prefer additive, testable changes.
+- Validation is required: state exact test commands and expected outputs; include concise evidence (logs, transcripts, diffs) as indented examples.
+
+## Milestones
+- Tell a story (goal → work → result → proof) for each milestone; keep them narrative rather than bureaucratic.
+- Each milestone must be independently verifiable and incrementally advance the overall goal.
+- Milestones are distinct from Progress: milestones explain the plan; Progress tracks real-time execution.
+
+## Living Sections (must be present and maintained)
+- Progress: checkbox list with timestamps; every pause should update what is done and what remains.
+- Surprises & Discoveries: unexpected behaviors, performance notes, or bugs with brief evidence.
+- Decision Log: each decision with rationale and date/author.
+- Outcomes & Retrospective: what was achieved, remaining gaps, and lessons learned.
+
+## Prototyping and Parallel Paths
+- Prototypes are encouraged to de-risk changes; keep them additive, clearly labeled, and validated.
+- Parallel implementations are acceptable when reducing risk; describe how to validate each path and how to retire one safely.
+
+## ExecPlan Skeleton
+
+```md
+# <Short, action-oriented description>
+
+This ExecPlan is a living document. The sections Progress, Surprises & Discoveries, Decision Log, and Outcomes & Retrospective must stay up to date as work proceeds.
+
+If PLANS.md is present in the repo, maintain this document in accordance with it and link back to it by path.
+
+## Purpose / Big Picture
+Explain the user-visible behavior gained after this change and how to observe it.
+
+## Progress
+- [x] (2025-10-01 13:00Z) Example completed step.
+- [ ] Example incomplete step.
+- [ ] Example partially completed step (completed: X; remaining: Y).
+
+## Surprises & Discoveries
+- Observation: …
+  Evidence: …
+
+## Decision Log
+- Decision: …
+  Rationale: …
+  Date/Author: …
+
+## Outcomes & Retrospective
+Summarize outcomes, gaps, and lessons learned; compare to the original purpose.
+
+## Context and Orientation
+Describe the current state relevant to this task as if the reader knows nothing. Name key files and modules by full path; define any non-obvious terms.
+
+## Plan of Work
+Prose description of the sequence of edits and additions. For each edit, name the file and location and what to change.
+
+## Concrete Steps
+Exact commands to run (with working directory). Include short expected outputs for comparison.
+
+## Validation and Acceptance
+Behavioral acceptance criteria plus test commands and expected results.
+
+## Idempotence and Recovery
+How to retry or roll back safely; ensure steps can be rerun without harm.
+
+## Artifacts and Notes
+Concise transcripts, diffs, or snippets as indented examples.
+
+## Interfaces and Dependencies
+Prescribe libraries, modules, and function signatures that must exist at the end. Use stable names and paths.
+```
+
+## Revising a Plan
+- When the scope shifts, rewrite affected sections so the document remains coherent and self-contained.
+- After significant edits, add a short note at the end explaining what changed and why.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,74 @@
+# Benchmarks
+
+This directory contains two benchmark drivers with different purposes. Always
+build the Rust extension in release mode before running either one; development
+build timings are not representative.
+
+```bash
+make install-release
+```
+
+## Cross-library benchmark
+
+`benchmarks.engine` compares `polars-h3` with the DuckDB H3 extension and the
+Python `h3` package. Use it to answer questions about how the libraries compare on the operations they have in common.
+
+The benchmark covers a focused set of common operations. Its row counts are
+grouped into basic, medium, and complex workloads. It also initializes the
+DuckDB H3 extension, so it may require network access the first time it runs.
+
+Run the complete comparison:
+
+```bash
+uv run -m benchmarks.engine
+```
+
+Run only `polars-h3`, reduce the workload, or select functions:
+
+```bash
+uv run -m benchmarks.engine --libraries plh3 --fast-factor 100
+uv run -m benchmarks.engine --functions latlng_to_cell grid_ring
+```
+
+## Internal performance benchmark
+
+`benchmarks.large_engine` measures `polars-h3` only. Use it for before-and-after
+optimization measurements and performance regression checks. It covers the
+public Rust-backed expressions, uses deterministic Polars-generated data, and
+assigns row counts per function so list- and geometry-producing operations do
+not overwhelm memory.
+
+Run all cases at their configured sizes:
+
+```bash
+uv run -m benchmarks.large_engine --iterations 3
+```
+
+For a faster local check, cap every case at the same maximum row count:
+
+```bash
+uv run -m benchmarks.large_engine --iterations 3 --max-rows 500000
+```
+
+Run selected cases and save the raw measurements:
+
+```bash
+uv run -m benchmarks.large_engine \
+  --functions cell_to_children grid_ring directed_edge_to_cells \
+  --iterations 5 \
+  --output /tmp/polars-h3-benchmark.json
+```
+
+## Choosing a benchmark
+
+Use `benchmarks.engine` when the question is "How does `polars-h3` compare with
+other H3 implementations?" Use `benchmarks.large_engine` when the question is
+"Did this change make `polars-h3` faster?" The internal benchmark complements
+the cross-library benchmark; it does not replace it.
+
+For reliable before-and-after results, use the same machine, release profile,
+row counts, selected functions, and iteration count for both builds. Treat
+small differences in cases that complete in only a few milliseconds as timing
+noise. Prefer several iterations and larger configured row counts before
+claiming a modest speedup. Write generated JSON results to `/tmp` unless there
+is a deliberate reason to preserve a result in the repository.

--- a/benchmarks/large_engine.py
+++ b/benchmarks/large_engine.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import polars as pl
+
+import polars_h3 as plh3
+
+RESOLUTION = 9
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    rows: int
+    expr: Callable[[], pl.Expr]
+
+
+@dataclass
+class Result:
+    name: str
+    rows: int
+    avg_seconds: float
+    std_seconds: float
+    runs: list[float]
+
+
+def make_data(max_rows: int) -> pl.DataFrame:
+    idx = pl.int_range(0, max_rows, eager=True).cast(pl.Float64)
+    df = (
+        pl.DataFrame({"i": idx})
+        .with_columns(
+            lat=38.403 + (pl.col("i") % 3575) / 3575 * (41.978 - 38.403),
+            lon=-84.820 + (pl.col("i") % 4302) / 4302 * (-80.518 + 84.820),
+            lat2=38.403 + ((pl.col("i") + 17) % 3575) / 3575 * (41.978 - 38.403),
+            lon2=-84.820 + ((pl.col("i") + 17) % 4302) / 4302 * (-80.518 + 84.820),
+            resolution=(pl.col("i") % 16).cast(pl.UInt64),
+            resolution_i64=(pl.col("i") % 16).cast(pl.Int64),
+            local_i=(pl.col("i") % 3).cast(pl.Int32),
+            local_j=((pl.col("i") + 1) % 3).cast(pl.Int32),
+            child_pos=pl.lit(0, dtype=pl.UInt64),
+        )
+        .drop("i")
+    )
+
+    return df.with_columns(
+        int_h3_cell=plh3.latlng_to_cell("lat", "lon", RESOLUTION),
+        int_h3_cell_end=plh3.latlng_to_cell("lat2", "lon2", RESOLUTION),
+        str_h3_cell=plh3.latlng_to_cell(
+            "lat", "lon", RESOLUTION, return_dtype=pl.String
+        ),
+    )
+
+
+def cases() -> dict[str, Case]:
+    return {
+        "latlng_to_cell": Case(
+            "latlng_to_cell",
+            8_000_000,
+            lambda: plh3.latlng_to_cell("lat", "lon", RESOLUTION),
+        ),
+        "latlng_to_cell_string": Case(
+            "latlng_to_cell_string",
+            8_000_000,
+            lambda: plh3.latlng_to_cell(
+                "lat", "lon", RESOLUTION, return_dtype=pl.String
+            ),
+        ),
+        "cell_to_lat": Case(
+            "cell_to_lat", 8_000_000, lambda: plh3.cell_to_lat("int_h3_cell")
+        ),
+        "cell_to_lng": Case(
+            "cell_to_lng", 8_000_000, lambda: plh3.cell_to_lng("int_h3_cell")
+        ),
+        "cell_to_latlng": Case(
+            "cell_to_latlng", 8_000_000, lambda: plh3.cell_to_latlng("int_h3_cell")
+        ),
+        "cell_to_boundary": Case(
+            "cell_to_boundary",
+            2_000_000,
+            lambda: plh3.cell_to_boundary("int_h3_cell"),
+        ),
+        "get_resolution": Case(
+            "get_resolution", 8_000_000, lambda: plh3.get_resolution("int_h3_cell")
+        ),
+        "str_to_int": Case(
+            "str_to_int", 8_000_000, lambda: plh3.str_to_int("str_h3_cell")
+        ),
+        "int_to_str": Case(
+            "int_to_str", 8_000_000, lambda: plh3.int_to_str("int_h3_cell")
+        ),
+        "is_valid_cell": Case(
+            "is_valid_cell", 8_000_000, lambda: plh3.is_valid_cell("int_h3_cell")
+        ),
+        "is_pentagon": Case(
+            "is_pentagon", 8_000_000, lambda: plh3.is_pentagon("int_h3_cell")
+        ),
+        "is_res_class_III": Case(
+            "is_res_class_III", 8_000_000, lambda: plh3.is_res_class_III("int_h3_cell")
+        ),
+        "get_icosahedron_faces": Case(
+            "get_icosahedron_faces",
+            4_000_000,
+            lambda: plh3.get_icosahedron_faces("int_h3_cell"),
+        ),
+        "cell_to_parent": Case(
+            "cell_to_parent",
+            8_000_000,
+            lambda: plh3.cell_to_parent("int_h3_cell", RESOLUTION - 1),
+        ),
+        "cell_to_center_child": Case(
+            "cell_to_center_child",
+            8_000_000,
+            lambda: plh3.cell_to_center_child("int_h3_cell", RESOLUTION + 1),
+        ),
+        "cell_to_children_size": Case(
+            "cell_to_children_size",
+            8_000_000,
+            lambda: plh3.cell_to_children_size("int_h3_cell", RESOLUTION + 1),
+        ),
+        "cell_to_children": Case(
+            "cell_to_children",
+            4_000_000,
+            lambda: plh3.cell_to_children("int_h3_cell", RESOLUTION + 1),
+        ),
+        "cell_to_child_pos": Case(
+            "cell_to_child_pos",
+            8_000_000,
+            lambda: plh3.cell_to_child_pos("child", RESOLUTION),
+        ),
+        "child_pos_to_cell": Case(
+            "child_pos_to_cell",
+            8_000_000,
+            lambda: plh3.child_pos_to_cell("int_h3_cell", "child_pos", RESOLUTION + 1),
+        ),
+        "compact_cells": Case(
+            "compact_cells", 500_000, lambda: plh3.compact_cells("cell_list")
+        ),
+        "uncompact_cells": Case(
+            "uncompact_cells",
+            500_000,
+            lambda: plh3.uncompact_cells("cell_list", RESOLUTION + 1),
+        ),
+        "grid_distance": Case(
+            "grid_distance",
+            8_000_000,
+            lambda: plh3.grid_distance("int_h3_cell", "int_h3_cell_end"),
+        ),
+        "grid_ring": Case(
+            "grid_ring", 2_500_000, lambda: plh3.grid_ring("int_h3_cell", 3)
+        ),
+        "grid_disk": Case(
+            "grid_disk", 1_500_000, lambda: plh3.grid_disk("int_h3_cell", 3)
+        ),
+        "grid_path_cells": Case(
+            "grid_path_cells",
+            100_000,
+            lambda: plh3.grid_path_cells("int_h3_cell", "int_h3_cell_end"),
+        ),
+        "cell_to_local_ij": Case(
+            "cell_to_local_ij",
+            8_000_000,
+            lambda: plh3.cell_to_local_ij("int_h3_cell", "int_h3_cell"),
+        ),
+        "local_ij_to_cell": Case(
+            "local_ij_to_cell",
+            8_000_000,
+            lambda: plh3.local_ij_to_cell("int_h3_cell", "local_i", "local_j"),
+        ),
+        "cell_area": Case(
+            "cell_area", 8_000_000, lambda: plh3.cell_area("int_h3_cell")
+        ),
+        "great_circle_distance": Case(
+            "great_circle_distance",
+            8_000_000,
+            lambda: plh3.great_circle_distance("lat", "lon", "lat2", "lon2"),
+        ),
+        "average_hexagon_area": Case(
+            "average_hexagon_area",
+            8_000_000,
+            lambda: plh3.average_hexagon_area("resolution"),
+        ),
+        "average_hexagon_edge_length": Case(
+            "average_hexagon_edge_length",
+            8_000_000,
+            lambda: plh3.average_hexagon_edge_length("resolution"),
+        ),
+        "get_num_cells": Case(
+            "get_num_cells", 8_000_000, lambda: plh3.get_num_cells("resolution")
+        ),
+        "get_pentagons": Case(
+            "get_pentagons", 4_000_000, lambda: plh3.get_pentagons("resolution_i64")
+        ),
+        "are_neighbor_cells": Case(
+            "are_neighbor_cells",
+            8_000_000,
+            lambda: plh3.are_neighbor_cells("int_h3_cell", "neighbor"),
+        ),
+        "cells_to_directed_edge": Case(
+            "cells_to_directed_edge",
+            8_000_000,
+            lambda: plh3.cells_to_directed_edge("int_h3_cell", "neighbor"),
+        ),
+        "is_valid_directed_edge": Case(
+            "is_valid_directed_edge",
+            8_000_000,
+            lambda: plh3.is_valid_directed_edge("edge"),
+        ),
+        "get_directed_edge_origin": Case(
+            "get_directed_edge_origin",
+            8_000_000,
+            lambda: plh3.get_directed_edge_origin("edge"),
+        ),
+        "get_directed_edge_destination": Case(
+            "get_directed_edge_destination",
+            8_000_000,
+            lambda: plh3.get_directed_edge_destination("edge"),
+        ),
+        "directed_edge_to_cells": Case(
+            "directed_edge_to_cells",
+            4_000_000,
+            lambda: plh3.directed_edge_to_cells("edge"),
+        ),
+        "origin_to_directed_edges": Case(
+            "origin_to_directed_edges",
+            4_000_000,
+            lambda: plh3.origin_to_directed_edges("int_h3_cell"),
+        ),
+        "directed_edge_to_boundary": Case(
+            "directed_edge_to_boundary",
+            2_000_000,
+            lambda: plh3.directed_edge_to_boundary("edge"),
+        ),
+        "edge_length": Case("edge_length", 8_000_000, lambda: plh3.edge_length("edge")),
+        "cell_to_vertex": Case(
+            "cell_to_vertex", 8_000_000, lambda: plh3.cell_to_vertex("int_h3_cell", 0)
+        ),
+        "cell_to_vertexes": Case(
+            "cell_to_vertexes", 4_000_000, lambda: plh3.cell_to_vertexes("int_h3_cell")
+        ),
+        "vertex_to_latlng": Case(
+            "vertex_to_latlng", 8_000_000, lambda: plh3.vertex_to_latlng("vertex")
+        ),
+        "is_valid_vertex": Case(
+            "is_valid_vertex", 8_000_000, lambda: plh3.is_valid_vertex("vertex")
+        ),
+    }
+
+
+def run_case(df: pl.DataFrame, case: Case, iterations: int) -> Result:
+    frame = prepare_frame(df.head(case.rows), case.name)
+    rows = frame.height
+    times: list[float] = []
+
+    for _ in range(iterations):
+        gc.collect()
+        start = time.perf_counter()
+        out = frame.with_columns(result=case.expr())
+        out.select("result").head(1)
+        times.append(time.perf_counter() - start)
+        del out
+
+    return Result(
+        name=case.name,
+        rows=rows,
+        avg_seconds=statistics.mean(times),
+        std_seconds=statistics.stdev(times) if len(times) > 1 else 0.0,
+        runs=times,
+    )
+
+
+def prepare_frame(frame: pl.DataFrame, name: str) -> pl.DataFrame:
+    needs_neighbor = {
+        "are_neighbor_cells",
+        "cells_to_directed_edge",
+    }
+    needs_edge = {
+        "is_valid_directed_edge",
+        "get_directed_edge_origin",
+        "get_directed_edge_destination",
+        "directed_edge_to_cells",
+        "directed_edge_to_boundary",
+        "edge_length",
+    }
+    needs_vertex = {
+        "vertex_to_latlng",
+        "is_valid_vertex",
+    }
+    needs_child = {"cell_to_child_pos"}
+    needs_cell_list = {"compact_cells", "uncompact_cells"}
+
+    if name in needs_neighbor or name in needs_edge:
+        frame = frame.with_columns(
+            neighbor=plh3.grid_ring("int_h3_cell", 1).list.get(1)
+        )
+    if name in needs_edge:
+        frame = frame.with_columns(
+            edge=plh3.cells_to_directed_edge("int_h3_cell", "neighbor")
+        )
+    if name in needs_vertex:
+        frame = frame.with_columns(vertex=plh3.cell_to_vertex("int_h3_cell", 0))
+    if name in needs_child:
+        frame = frame.with_columns(
+            child=plh3.cell_to_center_child("int_h3_cell", RESOLUTION + 1)
+        )
+    if name in needs_cell_list:
+        frame = frame.with_columns(cell_list=plh3.grid_disk("int_h3_cell", 1))
+
+    return frame
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Large plh3-only benchmarks")
+    parser.add_argument("--functions", "-f", nargs="+", default=["all"])
+    parser.add_argument("--iterations", "-n", type=int, default=3)
+    parser.add_argument("--max-rows", type=int, default=None)
+    parser.add_argument("--output", "-o", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    all_cases = cases()
+    selected = (
+        list(all_cases.values())
+        if "all" in args.functions
+        else [all_cases[name] for name in args.functions]
+    )
+    max_rows = args.max_rows or max(case.rows for case in selected)
+
+    print(f"Generating {max_rows:,} rows")
+    df = make_data(max_rows)
+
+    results = [run_case(df, case, args.iterations) for case in selected]
+
+    print(f"{'function':<28} {'rows':>10} {'avg':>10} {'std':>10}")
+    for result in results:
+        print(
+            f"{result.name:<28} {result.rows:>10,} "
+            f"{result.avg_seconds:>9.3f}s {result.std_seconds:>9.3f}s"
+        )
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps([asdict(result) for result in results], indent=2)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/polars_h3/core/traversal.py
+++ b/polars_h3/core/traversal.py
@@ -95,6 +95,7 @@ def grid_ring(cell: IntoExprColumn, k: IntoExprColumn | int) -> pl.Expr:
     - `ValueError`: If `k < 0`.
     - `ComputeError`: If pentagonal distortion or invalid inputs prevent computation.
     """
+    k_expr: IntoExprColumn
     if isinstance(k, int):
         if k < 0:
             raise ValueError("k must be non-negative")
@@ -145,6 +146,7 @@ def grid_disk(cell: IntoExprColumn, k: IntoExprColumn | int) -> pl.Expr:
     - `ValueError`: If `k < 0`.
     - `ComputeError`: If pentagonal distortion or invalid inputs prevent computation.
     """
+    k_expr: IntoExprColumn
     if isinstance(k, int):
         if k < 0:
             raise ValueError("k must be non-negative")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = []
 module = "polars.utils.udfs"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["folium", "matplotlib"]
+ignore_missing_imports = true
+
 [dependency-groups]
 dev = [
     "maturin",

--- a/src/engine/edge.rs
+++ b/src/engine/edge.rs
@@ -2,7 +2,7 @@ use h3o::DirectedEdgeIndex;
 use polars::prelude::*;
 use rayon::prelude::*;
 
-use super::utils::parse_cell_indices;
+use super::utils::{list_u64_vecs_to_series, parse_cell_indices};
 
 pub fn are_neighbor_cells(
     origin_series: &Series,
@@ -136,53 +136,72 @@ pub fn get_directed_edge_destination(edge_series: &Series) -> PolarsResult<Serie
 pub fn directed_edge_to_cells(edge_series: &Series) -> PolarsResult<Series> {
     let edges = parse_edge_indices(edge_series)?;
 
-    let cell_pairs: ListChunked = edges
+    let cell_pairs: Vec<Option<[u64; 2]>> = edges
         .into_par_iter()
-        .map(|edge| {
-            edge.map(|idx| {
-                Series::new(
-                    PlSmallStr::from_str(""),
-                    &[u64::from(idx.origin()), u64::from(idx.destination())],
-                )
-            })
-        })
+        .map(|edge| edge.map(|idx| [u64::from(idx.origin()), u64::from(idx.destination())]))
         .collect();
 
-    Ok(cell_pairs.into_series())
+    let mut builder = ListPrimitiveChunkedBuilder::<UInt64Type>::new(
+        PlSmallStr::from(""),
+        cell_pairs.len(),
+        cell_pairs.len() * 2,
+        DataType::UInt64,
+    );
+    for opt_pair in cell_pairs {
+        match opt_pair {
+            Some(pair) => builder.append_slice(&pair),
+            None => builder.append_null(),
+        }
+    }
+
+    Ok(builder.finish().into_series())
 }
 
 pub fn origin_to_directed_edges(cell_series: &Series) -> PolarsResult<Series> {
     let cells = parse_cell_indices(cell_series)?;
 
-    let edges: ListChunked = cells
+    let edges: Vec<Option<Vec<u64>>> = cells
         .into_par_iter()
-        .map(|cell| {
-            cell.map(|idx| {
-                let edge_list: Vec<u64> = idx.edges().map(Into::into).collect();
-                Series::new(PlSmallStr::from_str(""), edge_list.as_slice())
-            })
-        })
+        .map(|cell| cell.map(|idx| idx.edges().map(Into::into).collect()))
         .collect();
 
-    Ok(edges.into_series())
+    list_u64_vecs_to_series(PlSmallStr::from(""), edges, &DataType::UInt64)
 }
 
 pub fn directed_edge_to_boundary(edge_series: &Series) -> PolarsResult<Series> {
     let edges = parse_edge_indices(edge_series)?;
 
-    let boundaries: ListChunked = edges
+    let boundaries: Vec<Option<Vec<f64>>> = edges
         .into_par_iter()
         .map(|edge| {
             edge.map(|idx| {
                 let boundary = idx.boundary();
-                let coords: Vec<f64> = boundary
-                    .iter()
-                    .flat_map(|latlng| vec![latlng.lat(), latlng.lng()])
-                    .collect();
-                Series::new(PlSmallStr::from_str(""), coords.as_slice())
+                let mut coords = Vec::with_capacity(boundary.len() * 2);
+                for latlng in boundary.iter() {
+                    coords.push(latlng.lat());
+                    coords.push(latlng.lng());
+                }
+                coords
             })
         })
         .collect();
 
-    Ok(boundaries.into_series())
+    let values_capacity = boundaries
+        .iter()
+        .filter_map(|opt| opt.as_ref().map(Vec::len))
+        .sum();
+    let mut builder = ListPrimitiveChunkedBuilder::<Float64Type>::new(
+        PlSmallStr::from(""),
+        boundaries.len(),
+        values_capacity,
+        DataType::Float64,
+    );
+    for opt_boundary in boundaries {
+        match opt_boundary {
+            Some(boundary) => builder.append_slice(&boundary),
+            None => builder.append_null(),
+        }
+    }
+
+    Ok(builder.finish().into_series())
 }

--- a/src/engine/hierarchy.rs
+++ b/src/engine/hierarchy.rs
@@ -3,7 +3,7 @@ use polars::prelude::*;
 use rayon::prelude::*;
 
 use super::utils::{
-    cast_list_u64_to_dtype, cast_u64_to_dtype, parse_cell_indices, resolve_target_inner_dtype,
+    cast_u64_to_dtype, list_u64_vecs_to_series, parse_cell_indices, resolve_target_inner_dtype,
 };
 
 fn get_target_resolution(cell: CellIndex, target_res: Option<u8>) -> Option<Resolution> {
@@ -93,24 +93,19 @@ pub fn cell_to_children(cell_series: &Series, child_res: Option<u8>) -> PolarsRe
     let original_dtype = cell_series.dtype().clone();
     let cells = parse_cell_indices(cell_series)?;
 
-    let children: ListChunked = cells
+    let children: Vec<Option<Vec<u64>>> = cells
         .into_par_iter()
         .map(|cell| {
             cell.map(|idx| {
                 let target_res = get_target_resolution(idx, child_res)
                     .unwrap_or_else(|| idx.resolution().succ().unwrap_or(idx.resolution()));
-                let children: Vec<u64> = idx.children(target_res).map(Into::into).collect();
-                Series::new(PlSmallStr::from(""), children.as_slice())
+                idx.children(target_res).map(Into::into).collect()
             })
         })
         .collect();
 
-    let children_series = children.into_series();
-
     let target_dtype = resolve_target_inner_dtype(&original_dtype)?;
-    let casted_children =
-        cast_list_u64_to_dtype(&children_series, &DataType::UInt64, Some(&target_dtype))?;
-    Ok(casted_children)
+    list_u64_vecs_to_series(PlSmallStr::from(""), children, &target_dtype)
 }
 
 pub fn cell_to_child_pos(child_series: &Series, parent_res: u8) -> PolarsResult<Series> {
@@ -161,12 +156,12 @@ pub fn compact_cells(cell_series: &Series) -> PolarsResult<Series> {
     let original_dtype = cell_series.dtype().clone();
 
     // Perform the compaction logic
-    let out_series = if let DataType::List(_) = cell_series.dtype() {
+    let compacted_values: Vec<Option<Vec<u64>>> = if let DataType::List(_) = cell_series.dtype() {
         // Input is already a List column
         let ca = cell_series.list()?;
         let cells_vec: Vec<_> = ca.into_iter().collect();
 
-        let compacted: ListChunked = cells_vec
+        cells_vec
             .into_par_iter()
             .map(|opt_series| {
                 opt_series
@@ -178,19 +173,11 @@ pub fn compact_cells(cell_series: &Series) -> PolarsResult<Series> {
                             .map_err(|e| {
                                 PolarsError::ComputeError(format!("Compaction error: {}", e).into())
                             })
-                            .map(|compacted| {
-                                // Note: `compacted` is a Vec<CellIndex>.
-                                // Convert to `u64` and store as a Series of UInt64.
-                                let compacted_u64: Vec<u64> =
-                                    compacted.into_iter().map(u64::from).collect();
-                                Series::new(PlSmallStr::from(""), compacted_u64.as_slice())
-                            })
+                            .map(|compacted| compacted.into_iter().map(u64::from).collect())
                     })
                     .transpose()
             })
-            .collect::<PolarsResult<_>>()?;
-
-        compacted.into_series()
+            .collect::<PolarsResult<_>>()?
     } else {
         // Input is not a list, so we treat it as a single column of cells.
         let cells = parse_cell_indices(cell_series)?;
@@ -199,16 +186,7 @@ pub fn compact_cells(cell_series: &Series) -> PolarsResult<Series> {
         let compacted = CellIndex::compact(cell_vec)
             .map_err(|e| PolarsError::ComputeError(format!("Compaction error: {}", e).into()))?;
 
-        // Wrap in a single List
-        let compacted_u64: Vec<u64> = compacted.into_iter().map(u64::from).collect();
-        let compacted_cells: ListChunked = vec![Some(Series::new(
-            PlSmallStr::from(""),
-            compacted_u64.as_slice(),
-        ))]
-        .into_iter()
-        .collect();
-
-        compacted_cells.into_series()
+        vec![Some(compacted.into_iter().map(u64::from).collect())]
     };
 
     // Determine the target inner dtype based on the original column
@@ -220,7 +198,7 @@ pub fn compact_cells(cell_series: &Series) -> PolarsResult<Series> {
 
     let target_inner_dtype = resolve_target_inner_dtype(&inner_original_dtype)?;
 
-    cast_list_u64_to_dtype(&out_series, &DataType::UInt64, Some(&target_inner_dtype))
+    list_u64_vecs_to_series(PlSmallStr::from(""), compacted_values, &target_inner_dtype)
 }
 
 pub fn uncompact_cells(cell_series: &Series, res: u8) -> PolarsResult<Series> {
@@ -229,12 +207,12 @@ pub fn uncompact_cells(cell_series: &Series, res: u8) -> PolarsResult<Series> {
         .map_err(|_| PolarsError::ComputeError("Invalid resolution".into()))?;
 
     // Perform the uncompact logic
-    let out_series = if let DataType::List(_) = cell_series.dtype() {
+    let uncompacted_values: Vec<Option<Vec<u64>>> = if let DataType::List(_) = cell_series.dtype() {
         // Input is already a List column
         let ca = cell_series.list()?;
         let cells_vec: Vec<_> = ca.into_iter().collect();
 
-        let uncompacted: ListChunked = cells_vec
+        cells_vec
             .into_par_iter()
             .map(|opt_series| {
                 opt_series
@@ -243,36 +221,18 @@ pub fn uncompact_cells(cell_series: &Series, res: u8) -> PolarsResult<Series> {
                         let cell_vec: Vec<_> = cells.into_iter().flatten().collect();
 
                         let uncompacted = CellIndex::uncompact(cell_vec, target_res);
-                        // Convert the CellIndex result to a UInt64 Series
-                        let uncompacted_u64: Vec<u64> =
-                            uncompacted.into_iter().map(u64::from).collect();
-                        Ok(Series::new(
-                            PlSmallStr::from(""),
-                            uncompacted_u64.as_slice(),
-                        ))
+                        Ok(uncompacted.into_iter().map(u64::from).collect())
                     })
                     .transpose()
             })
-            .collect::<PolarsResult<_>>()?;
-
-        uncompacted.into_series()
+            .collect::<PolarsResult<_>>()?
     } else {
         // Input is not a list, treat it as a single column of cells.
         let cells = parse_cell_indices(cell_series)?;
         let cell_vec: Vec<_> = cells.into_iter().flatten().collect();
 
         let uncompacted = CellIndex::uncompact(cell_vec, target_res);
-        let uncompacted_u64: Vec<u64> = uncompacted.into_iter().map(u64::from).collect();
-
-        // Wrap in a single List
-        let uncompacted_cells: ListChunked = vec![Some(Series::new(
-            PlSmallStr::from(""),
-            uncompacted_u64.as_slice(),
-        ))]
-        .into_iter()
-        .collect();
-
-        uncompacted_cells.into_series()
+        vec![Some(uncompacted.into_iter().map(u64::from).collect())]
     };
 
     // Determine the target inner dtype based on the original column
@@ -283,6 +243,9 @@ pub fn uncompact_cells(cell_series: &Series, res: u8) -> PolarsResult<Series> {
 
     // Map original inner dtype to the target dtype
     let target_inner_dtype = resolve_target_inner_dtype(&inner_original_dtype)?;
-    // We have a List(UInt64) right now, cast it to List(target_inner_dtype)
-    cast_list_u64_to_dtype(&out_series, &DataType::UInt64, Some(&target_inner_dtype))
+    list_u64_vecs_to_series(
+        PlSmallStr::from(""),
+        uncompacted_values,
+        &target_inner_dtype,
+    )
 }

--- a/src/engine/indexing.rs
+++ b/src/engine/indexing.rs
@@ -107,17 +107,30 @@ pub fn cell_to_lng(cell_series: &Series) -> PolarsResult<Series> {
 pub fn cell_to_latlng(cell_series: &Series) -> PolarsResult<Series> {
     let cells = parse_cell_indices(cell_series)?;
 
-    let coords: ListChunked = cells
+    let coords: Vec<Option<[f64; 2]>> = cells
         .into_par_iter()
         .map(|cell| {
             cell.map(|idx| {
                 let latlng = LatLng::from(idx);
-                Series::new(PlSmallStr::from(""), &[latlng.lat(), latlng.lng()])
+                [latlng.lat(), latlng.lng()]
             })
         })
         .collect();
 
-    Ok(coords.into_series())
+    let mut builder = ListPrimitiveChunkedBuilder::<Float64Type>::new(
+        PlSmallStr::from(""),
+        coords.len(),
+        coords.len() * 2,
+        DataType::Float64,
+    );
+    for opt_coord in coords {
+        match opt_coord {
+            Some(coord) => builder.append_slice(&coord),
+            None => builder.append_null(),
+        }
+    }
+
+    Ok(builder.finish().into_series())
 }
 
 pub fn cell_to_boundary(cell_series: &Series) -> PolarsResult<Series> {
@@ -128,20 +141,18 @@ pub fn cell_to_boundary(cell_series: &Series) -> PolarsResult<Series> {
         .map(|cell| {
             cell.map(|idx| {
                 let boundary = idx.boundary();
+                let mut builder = ListPrimitiveChunkedBuilder::<Float64Type>::new(
+                    PlSmallStr::from(""),
+                    boundary.len(),
+                    boundary.len() * 2,
+                    DataType::Float64,
+                );
 
-                // Create a Vec<Vec<f64>> for the boundary: each inner vec is [lat, lng]
-                let latlng_pairs: Vec<Vec<f64>> = boundary
-                    .iter()
-                    .map(|vertex| vec![vertex.lat(), vertex.lng()])
-                    .collect();
+                for vertex in boundary.iter() {
+                    builder.append_slice(&[vertex.lat(), vertex.lng()]);
+                }
 
-                // Convert each [lat, lng] pair into its own Series
-                let inner_series: Vec<Series> = latlng_pairs
-                    .into_iter()
-                    .map(|coords| Series::new(PlSmallStr::from(""), coords))
-                    .collect();
-
-                Series::new(PlSmallStr::from(""), inner_series)
+                builder.finish().into_series()
             })
         })
         .collect();

--- a/src/engine/inspection.rs
+++ b/src/engine/inspection.rs
@@ -33,17 +33,32 @@ pub fn str_to_int(cell_series: &Series) -> PolarsResult<Series> {
 }
 
 pub fn int_to_str(cell_series: &Series) -> PolarsResult<Series> {
-    let cells = match cell_series.dtype() {
-        DataType::UInt64 => cell_series
-            .u64()?
-            .into_iter()
-            .map(|opt| opt.and_then(|v| CellIndex::try_from(v).ok()))
-            .collect::<Vec<_>>(),
-        DataType::Int64 => cell_series
-            .i64()?
-            .into_iter()
-            .map(|opt| opt.and_then(|v| CellIndex::try_from(v as u64).ok()))
-            .collect::<Vec<_>>(),
+    let strings: Vec<Option<String>> = match cell_series.dtype() {
+        DataType::UInt64 => {
+            let values: Vec<_> = cell_series.u64()?.into_iter().collect();
+            values
+                .into_par_iter()
+                .map(|opt| {
+                    opt.and_then(|v| {
+                        CellIndex::try_from(v).ok()?;
+                        Some(format!("{:x}", v))
+                    })
+                })
+                .collect()
+        },
+        DataType::Int64 => {
+            let values: Vec<_> = cell_series.i64()?.into_iter().collect();
+            values
+                .into_par_iter()
+                .map(|opt| {
+                    opt.and_then(|v| {
+                        let v: u64 = v.try_into().ok()?;
+                        CellIndex::try_from(v).ok()?;
+                        Some(format!("{:x}", v))
+                    })
+                })
+                .collect()
+        },
         _ => {
             return Err(PolarsError::ComputeError(
                 format!("Expected UInt64 or Int64, got: {:?}", cell_series.dtype()).into(),
@@ -51,10 +66,7 @@ pub fn int_to_str(cell_series: &Series) -> PolarsResult<Series> {
         },
     };
 
-    let strings: StringChunked = cells
-        .into_iter()
-        .map(|opt_cell| opt_cell.map(|cell| cell.to_string()))
-        .collect();
+    let strings: StringChunked = strings.into_iter().collect();
 
     Ok(strings.into_series())
 }
@@ -127,23 +139,32 @@ pub fn is_res_class_III(cell_series: &Series) -> PolarsResult<Series> {
 pub fn get_icosahedron_faces(cell_series: &Series) -> PolarsResult<Series> {
     let cells = parse_cell_indices(cell_series)?;
 
-    let faces: ListChunked = cells
+    let faces: Vec<Option<Vec<i64>>> = cells
         .into_par_iter()
         .map(|cell| {
             cell.map(|idx| {
                 let faces = idx.icosahedron_faces();
-                // Convert faces set to vec of integers
-                Series::new(
-                    PlSmallStr::from(""),
-                    faces
-                        .iter()
-                        .map(|f| u8::from(f) as i64)
-                        .collect::<Vec<_>>()
-                        .as_slice(),
-                )
+                faces.iter().map(|f| u8::from(f) as i64).collect()
             })
         })
         .collect();
 
-    Ok(faces.into_series())
+    let values_capacity = faces
+        .iter()
+        .filter_map(|opt| opt.as_ref().map(Vec::len))
+        .sum();
+    let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
+        PlSmallStr::from(""),
+        faces.len(),
+        values_capacity,
+        DataType::Int64,
+    );
+    for opt_faces in faces {
+        match opt_faces {
+            Some(faces) => builder.append_slice(&faces),
+            None => builder.append_null(),
+        }
+    }
+
+    Ok(builder.finish().into_series())
 }

--- a/src/engine/metrics.rs
+++ b/src/engine/metrics.rs
@@ -1,7 +1,8 @@
+use std::str::FromStr;
+
 use h3o::{CellIndex, DirectedEdgeIndex, Resolution};
 use polars::prelude::*;
 use rayon::prelude::*;
-use std::str::FromStr;
 
 use super::utils::parse_cell_indices;
 
@@ -86,15 +87,70 @@ pub fn get_res0_cells() -> PolarsResult<Series> {
 pub fn get_pentagons(inputs: &[Series]) -> PolarsResult<Series> {
     let resolutions: Vec<Option<u8>> = match inputs[0].dtype() {
         DataType::UInt8 => Ok::<_, PolarsError>(inputs[0].u8()?.into_iter().collect()),
+        DataType::UInt16 => Ok::<_, PolarsError>(
+            inputs[0]
+                .u16()?
+                .into_iter()
+                .map(|opt| {
+                    opt.map(|v| {
+                        u8::try_from(v)
+                            .map_err(|_| polars_err!(ComputeError: "Invalid resolution: {}", v))
+                    })
+                    .transpose()
+                })
+                .collect::<PolarsResult<_>>()?,
+        ),
+        DataType::UInt32 => Ok::<_, PolarsError>(
+            inputs[0]
+                .u32()?
+                .into_iter()
+                .map(|opt| {
+                    opt.map(|v| {
+                        u8::try_from(v)
+                            .map_err(|_| polars_err!(ComputeError: "Invalid resolution: {}", v))
+                    })
+                    .transpose()
+                })
+                .collect::<PolarsResult<_>>()?,
+        ),
+        DataType::UInt64 => Ok::<_, PolarsError>(
+            inputs[0]
+                .u64()?
+                .into_iter()
+                .map(|opt| {
+                    opt.map(|v| {
+                        u8::try_from(v)
+                            .map_err(|_| polars_err!(ComputeError: "Invalid resolution: {}", v))
+                    })
+                    .transpose()
+                })
+                .collect::<PolarsResult<_>>()?,
+        ),
         DataType::Int64 => Ok::<_, PolarsError>(
             inputs[0]
                 .i64()?
                 .into_iter()
-                .map(|opt| opt.map(|v| v as u8))
-                .collect(),
+                .map(|opt| {
+                    opt.map(|v| {
+                        u8::try_from(v)
+                            .map_err(|_| polars_err!(ComputeError: "Invalid resolution: {}", v))
+                    })
+                    .transpose()
+                })
+                .collect::<PolarsResult<_>>()?,
         ),
-        _ => polars_bail!(ComputeError: "Expected UInt8 or Int64 for resolutions"),
+        _ => polars_bail!(ComputeError: "Expected an integer dtype for resolutions"),
     }?;
+
+    let pentagons_by_res: Vec<Vec<u64>> = (0u8..=15)
+        .map(|res| {
+            Resolution::try_from(res)
+                .expect("0..=15 are valid H3 resolutions")
+                .pentagons()
+                .map(Into::into)
+                .collect()
+        })
+        .collect();
 
     let mut builder = ListPrimitiveChunkedBuilder::<UInt64Type>::new(
         PlSmallStr::from("pentagons"),
@@ -106,14 +162,10 @@ pub fn get_pentagons(inputs: &[Series]) -> PolarsResult<Series> {
     for res_opt in resolutions {
         match res_opt {
             Some(res) => {
-                let pentagons: Vec<u64> = Resolution::try_from(res)
-                    .map_err(|e| {
-                        PolarsError::ComputeError(format!("Error getting pentagons: {}", e).into())
-                    })?
-                    .pentagons()
-                    .map(|cell| cell.into())
-                    .collect();
-                builder.append_slice(&pentagons);
+                let pentagons = pentagons_by_res.get(res as usize).ok_or_else(|| {
+                    PolarsError::ComputeError(format!("Invalid resolution: {}", res).into())
+                })?;
+                builder.append_slice(pentagons);
             },
             None => {
                 builder.append_null();

--- a/src/engine/traversal.rs
+++ b/src/engine/traversal.rs
@@ -1,9 +1,8 @@
-use h3o::CellIndex;
-use h3o::CoordIJ;
+use h3o::{CellIndex, CoordIJ};
 use polars::prelude::*;
 use rayon::prelude::*;
 
-use super::utils::{cast_list_u64_to_dtype, parse_cell_indices, resolve_target_inner_dtype};
+use super::utils::{list_u64_vecs_to_series, parse_cell_indices, resolve_target_inner_dtype};
 
 pub fn grid_distance(origin_series: &Series, destination_series: &Series) -> PolarsResult<Series> {
     let origins = parse_cell_indices(origin_series)?;
@@ -85,19 +84,8 @@ pub fn grid_ring(inputs: &[Series]) -> PolarsResult<Series> {
             .collect()
     };
 
-    let rings: ListChunked = ring_results
-        .into_iter()
-        .map(|opt| opt.map(|rings| Series::new(PlSmallStr::from(""), rings.as_slice())))
-        .collect::<Vec<_>>()
-        .into_iter()
-        .collect();
-
     let target_inner_dtype = super::utils::resolve_target_inner_dtype(cell_series.dtype())?;
-    super::utils::cast_list_u64_to_dtype(
-        &rings.into_series(),
-        &DataType::UInt64,
-        Some(&target_inner_dtype),
-    )
+    list_u64_vecs_to_series(PlSmallStr::from(""), ring_results, &target_inner_dtype)
 }
 
 pub fn grid_disk(inputs: &[Series]) -> PolarsResult<Series> {
@@ -166,14 +154,7 @@ pub fn grid_disk(inputs: &[Series]) -> PolarsResult<Series> {
             .collect()
     };
 
-    // Convert results to a ListChunked series
-    let disks: ListChunked = disk_results
-        .into_iter()
-        .map(|opt| opt.map(|disk| Series::new(PlSmallStr::from(""), disk.as_slice())))
-        .collect();
-
-    let disks_series = disks.into_series();
-    cast_list_u64_to_dtype(&disks_series, &DataType::UInt64, Some(&target_inner_dtype))
+    list_u64_vecs_to_series(PlSmallStr::from(""), disk_results, &target_inner_dtype)
 }
 
 pub fn grid_path_cells(
@@ -187,27 +168,24 @@ pub fn grid_path_cells(
     // Convert to Vec to ensure parallel iteration works
     let dest_vec: Vec<_> = destinations.into_iter().collect();
 
-    let paths: ListChunked = origins
+    let paths: Vec<Option<Vec<u64>>> = origins
         .into_par_iter()
         .zip(dest_vec.into_par_iter())
         .map(|(origin, dest)| {
             match (origin, dest) {
                 (Some(org), Some(dst)) => {
                     // Collect all cells in the path, handling errors by returning None
-                    org.grid_path_cells(dst).ok().map(|path| {
-                        let path_cells: Vec<u64> =
-                            path.filter_map(Result::ok).map(Into::into).collect();
-                        Series::new(PlSmallStr::from(""), path_cells.as_slice())
-                    })
+                    org.grid_path_cells(dst)
+                        .ok()
+                        .map(|path| path.filter_map(Result::ok).map(Into::into).collect())
                 },
                 _ => None,
             }
         })
         .collect();
 
-    let paths_series = paths.into_series();
     let target_inner_dtype = resolve_target_inner_dtype(&original_dtype)?;
-    cast_list_u64_to_dtype(&paths_series, &DataType::UInt64, Some(&target_inner_dtype))
+    list_u64_vecs_to_series(PlSmallStr::from(""), paths, &target_inner_dtype)
 }
 
 pub fn cell_to_local_ij(cell_series: &Series, origin_series: &Series) -> PolarsResult<Series> {
@@ -216,21 +194,32 @@ pub fn cell_to_local_ij(cell_series: &Series, origin_series: &Series) -> PolarsR
 
     let origin_vec: Vec<_> = origins.into_iter().collect();
 
-    let coords: ListChunked = cells
+    let coords: Vec<Option<[f64; 2]>> = cells
         .into_par_iter()
         .zip(origin_vec.into_par_iter())
         .map(|(cell, origin)| match (cell, origin) {
-            (Some(cell), Some(origin)) => cell.to_local_ij(origin).ok().map(|local_ij| {
-                Series::new(
-                    PlSmallStr::from(""),
-                    &[local_ij.coord.i as f64, local_ij.coord.j as f64],
-                )
-            }),
+            (Some(cell), Some(origin)) => cell
+                .to_local_ij(origin)
+                .ok()
+                .map(|local_ij| [local_ij.coord.i as f64, local_ij.coord.j as f64]),
             _ => None,
         })
         .collect();
 
-    Ok(coords.into_series())
+    let mut builder = ListPrimitiveChunkedBuilder::<Float64Type>::new(
+        PlSmallStr::from(""),
+        coords.len(),
+        coords.len() * 2,
+        DataType::Float64,
+    );
+    for opt_coord in coords {
+        match opt_coord {
+            Some(coord) => builder.append_slice(&coord),
+            None => builder.append_null(),
+        }
+    }
+
+    Ok(builder.finish().into_series())
 }
 
 pub fn local_ij_to_cell(
@@ -245,10 +234,12 @@ pub fn local_ij_to_cell(
 
     let i_values = i_coords.i32()?;
     let j_values = j_coords.i32()?;
+    let i_vec: Vec<_> = i_values.into_iter().collect();
+    let j_vec: Vec<_> = j_values.into_iter().collect();
 
     let cells: UInt64Chunked = origins
-        .into_iter()
-        .zip(i_values.into_iter().zip(j_values))
+        .into_par_iter()
+        .zip(i_vec.into_par_iter().zip(j_vec.into_par_iter()))
         .map(|(origin, (i, j))| match (origin, i, j) {
             (Some(origin), Some(i), Some(j)) => {
                 let coord = CoordIJ { i, j };

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -96,6 +96,40 @@ pub fn cast_list_u64_to_dtype(
     Ok(out.into_series())
 }
 
+pub fn list_u64_vecs_to_series(
+    name: PlSmallStr,
+    values: Vec<Option<Vec<u64>>>,
+    target_inner_dtype: &DataType,
+) -> PolarsResult<Series> {
+    let values_capacity = values
+        .iter()
+        .filter_map(|opt| opt.as_ref().map(Vec::len))
+        .sum();
+    let mut builder = ListPrimitiveChunkedBuilder::<UInt64Type>::new(
+        name,
+        values.len(),
+        values_capacity,
+        DataType::UInt64,
+    );
+
+    for opt_values in values {
+        match opt_values {
+            Some(values) => builder.append_slice(&values),
+            None => builder.append_null(),
+        }
+    }
+
+    let out = builder.finish().into_series();
+    match target_inner_dtype {
+        DataType::UInt64 => Ok(out),
+        DataType::Int64 => out.cast(&DataType::List(Box::new(DataType::Int64))),
+        DataType::String => {
+            cast_list_u64_to_dtype(&out, &DataType::UInt64, Some(target_inner_dtype))
+        },
+        _ => polars_bail!(ComputeError: "Unsupported dtype for H3 List result"),
+    }
+}
+
 pub fn resolve_target_inner_dtype(original_dtype: &DataType) -> PolarsResult<DataType> {
     // If the original was a List, extract its inner type. Otherwise, use the original directly.
     let inner_original_dtype = match original_dtype {

--- a/src/engine/vertexes.rs
+++ b/src/engine/vertexes.rs
@@ -2,7 +2,7 @@ use h3o::{LatLng, Vertex, VertexIndex};
 use polars::prelude::*;
 use rayon::prelude::*;
 
-use super::utils::parse_cell_indices;
+use super::utils::{list_u64_vecs_to_series, parse_cell_indices};
 
 pub fn cell_to_vertex(cell_series: &Series, vertex_num: u8) -> PolarsResult<Series> {
     // Try to create vertex first to validate the number
@@ -23,17 +23,12 @@ pub fn cell_to_vertex(cell_series: &Series, vertex_num: u8) -> PolarsResult<Seri
 pub fn cell_to_vertexes(cell_series: &Series) -> PolarsResult<Series> {
     let cells = parse_cell_indices(cell_series)?;
 
-    let vertex_lists: ListChunked = cells
+    let vertex_lists: Vec<Option<Vec<u64>>> = cells
         .into_par_iter()
-        .map(|cell| {
-            cell.map(|idx| {
-                let vertices: Vec<u64> = idx.vertexes().map(Into::into).collect();
-                Series::new(PlSmallStr::from(""), vertices.as_slice())
-            })
-        })
+        .map(|cell| cell.map(|idx| idx.vertexes().map(Into::into).collect()))
         .collect();
 
-    Ok(vertex_lists.into_series())
+    list_u64_vecs_to_series(PlSmallStr::from(""), vertex_lists, &DataType::UInt64)
 }
 
 pub fn vertex_to_latlng(vertex_series: &Series) -> PolarsResult<Series> {
@@ -64,46 +59,65 @@ pub fn vertex_to_latlng(vertex_series: &Series) -> PolarsResult<Series> {
         },
     };
 
-    let coords: ListChunked = vertices
+    let coords: Vec<Option<[f64; 2]>> = vertices
         .into_par_iter()
         .map(|vertex| {
             vertex.map(|idx| {
                 let latlng = LatLng::from(idx);
-                Series::new(PlSmallStr::from(""), &[latlng.lat(), latlng.lng()])
+                [latlng.lat(), latlng.lng()]
             })
         })
         .collect();
 
-    Ok(coords.into_series())
+    let mut builder = ListPrimitiveChunkedBuilder::<Float64Type>::new(
+        PlSmallStr::from(""),
+        coords.len(),
+        coords.len() * 2,
+        DataType::Float64,
+    );
+    for opt_coord in coords {
+        match opt_coord {
+            Some(coord) => builder.append_slice(&coord),
+            None => builder.append_null(),
+        }
+    }
+
+    Ok(builder.finish().into_series())
 }
 
 pub fn is_valid_vertex(vertex_series: &Series) -> PolarsResult<Series> {
     let is_valid = match vertex_series.dtype() {
-        DataType::UInt64 => vertex_series
-            .u64()?
-            .into_iter()
-            .map(|opt| {
-                opt.map(|v| VertexIndex::try_from(v).is_ok())
-                    .unwrap_or(false)
-            })
-            .collect::<BooleanChunked>(),
-        DataType::Int64 => vertex_series
-            .i64()?
-            .into_iter()
-            .map(|opt| {
-                opt.map(|v| VertexIndex::try_from(v as u64).is_ok())
-                    .unwrap_or(false)
-            })
-            .collect::<BooleanChunked>(),
-        DataType::String => vertex_series
-            .str()?
-            .into_iter()
-            .map(|opt| {
-                opt.and_then(|s| u64::from_str_radix(s, 16).ok())
-                    .map(|v| VertexIndex::try_from(v).is_ok())
-                    .unwrap_or(false)
-            })
-            .collect::<BooleanChunked>(),
+        DataType::UInt64 => {
+            let values: Vec<_> = vertex_series.u64()?.into_iter().collect();
+            values
+                .into_par_iter()
+                .map(|opt| {
+                    opt.map(|v| VertexIndex::try_from(v).is_ok())
+                        .unwrap_or(false)
+                })
+                .collect::<BooleanChunked>()
+        },
+        DataType::Int64 => {
+            let values: Vec<_> = vertex_series.i64()?.into_iter().collect();
+            values
+                .into_par_iter()
+                .map(|opt| {
+                    opt.map(|v| VertexIndex::try_from(v as u64).is_ok())
+                        .unwrap_or(false)
+                })
+                .collect::<BooleanChunked>()
+        },
+        DataType::String => {
+            let values: Vec<_> = vertex_series.str()?.into_iter().collect();
+            values
+                .into_par_iter()
+                .map(|opt| {
+                    opt.and_then(|s| u64::from_str_radix(s, 16).ok())
+                        .map(|v| VertexIndex::try_from(v).is_ok())
+                        .unwrap_or(false)
+                })
+                .collect::<BooleanChunked>()
+        },
         _ => {
             return Err(PolarsError::ComputeError(
                 format!("Unsupported type for vertex: {:?}", vertex_series.dtype()).into(),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -369,3 +369,18 @@ def test_get_pentagons():
             ]
         else:
             assert val["h3_resolution"] in list(range(0, 16))
+
+
+@pytest.mark.parametrize(
+    ("resolution", "dtype"),
+    [
+        pytest.param(-1, pl.Int64, id="negative-int64"),
+        pytest.param(256, pl.Int64, id="oversized-int64"),
+        pytest.param(256, pl.UInt64, id="oversized-uint64"),
+    ],
+)
+def test_get_pentagons_invalid_resolution(resolution: int, dtype: pl.DataType):
+    df = pl.DataFrame({"resolution": [resolution]}, schema={"resolution": dtype})
+
+    with pytest.raises(pl.exceptions.ComputeError, match="Invalid resolution"):
+        df.select(plh3.get_pentagons("resolution"))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -1850,7 +1850,7 @@ wheels = [
 
 [[package]]
 name = "polars-h3"
-version = "0.5.7"
+version = "0.6.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- add contributor guidance, ExecPlan conventions, and streamlined Make targets
- add a large Polars-only benchmark driver and usage documentation
- replace per-row `Series` allocation with primitive list builders across Rust H3 expressions
- cache pentagon outputs, parallelize conversion paths, and preserve invalid-resolution errors
- update the PyPI workflow to run formatting, lint, build, and test checks

## Performance

The calibrated benchmark confirms substantial gains. “Before” is `fb45ecb`; “after” is `99171a8`. Each function used its full configured row count, with three samples per function.

| Function | Rows | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `get_pentagons` | 4.0M | 0.522s | 0.047s | **11.06×** |
| `directed_edge_to_cells` | 4.0M | 0.417s | 0.043s | **9.66×** |
| `cell_to_children` | 4.0M | 0.900s | 0.104s | **8.66×** |
| `is_valid_vertex` | 8.0M | 0.518s | 0.070s | **7.39×** |
| `grid_ring` | 2.5M | 0.942s | 0.129s | **7.29×** |
| `cell_to_local_ij` | 8.0M | 0.870s | 0.124s | **7.01×** |
| `local_ij_to_cell` | 8.0M | 0.883s | 0.144s | **6.12×** |
| `cell_to_latlng` | 8.0M | 0.932s | 0.152s | **6.12×** |
| `get_icosahedron_faces` | 4.0M | 0.403s | 0.091s | **4.44×** |
| `origin_to_directed_edges` | 4.0M | 0.437s | 0.104s | **4.20×** |
| `grid_disk` | 1.5M | 0.458s | 0.129s | **3.55×** |
| `directed_edge_to_boundary` | 2.0M | 0.257s | 0.088s | **2.91×** |
| `compact_cells` | 500K | 0.194s | 0.081s | **2.38×** |
| `cell_to_vertexes` | 4.0M | 0.632s | 0.270s | **2.34×** |
| `vertex_to_latlng` | 8.0M | 1.361s | 0.648s | **2.10×** |
| `uncompact_cells` | 500K | 0.212s | 0.103s | **2.06×** |
| `grid_path_cells` | 100K | 0.0437s | 0.0213s | **2.05×** |
| `int_to_str` | 8.0M | 0.307s | 0.174s | **1.77×** |
| `cell_to_boundary` | 2.0M | 0.778s | 0.634s | **1.23×** |
| `cell_to_vertex` | 8.0M | 0.108s | 0.098s | **1.11×** |

Across one execution of all 46 configured workloads:

- Before: **14.242s**
- After: **6.229s**
- Descriptive aggregate: **2.29× faster**
- No function regressed by more than 1.6%; those small differences are consistent with timing noise.

The raw benchmark JSON files were retained locally under `/tmp` and are not part of this PR.

## Validation

- `cargo clippy --all-features`
- `ruff check polars_h3 tests benchmarks`
- `mypy polars_h3`
- `pytest tests` — 197 passed
- all 46 benchmark cases smoke-tested at 1,000 rows
