### PR TITLE
Upgrade h3o to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -276,15 +276,16 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h3o"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537b141fa7998c2c993b9431247f6e2eb69d606bd51173ab85394792f3a7cdf7"
+checksum = "9fb2db7abbf5a95268cfb53ee6c2d4c02894323e1d3e1d7b300595eee61c482c"
 dependencies = [
  "ahash",
  "either",
  "float_eq",
  "h3o-bit",
  "libm",
+ "ordered-float",
 ]
 
 [[package]]
@@ -486,6 +487,15 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "ordered-float"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ pyo3 = { version = "0.21.2", features = ["extension-module", "abi3-py38"] }
 pyo3-polars = { version = "0.18.0", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 polars = { version = "0.44.2", default-features = false }
-h3o = "0.7.1"
+h3o = "0.11.0"
 rayon = "1.10.0"
 
 [profile.release]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,6 +12,12 @@ make install-release
 
 `benchmarks.engine` compares `polars-h3` with the DuckDB H3 extension and the
 Python `h3` package. Use it to answer questions about how the libraries compare on the operations they have in common.
+It runs one excluded warm-up by default and prints a direct DuckDB-to-`polars-h3`
+speedup table when both libraries are selected. Timings include producing a
+Polars result from each implementation, so interpret them as an end-to-end
+comparison for a Polars-based workload rather than isolated H3 call latency.
+The command also prints the concrete Polars, DuckDB, DuckDB H3 extension, and
+Python H3 versions used by the run.
 
 The benchmark covers a focused set of common operations. Its row counts are
 grouped into basic, medium, and complex workloads. It also initializes the

--- a/benchmarks/engine.py
+++ b/benchmarks/engine.py
@@ -3,7 +3,7 @@ Utility script to benchmark the performance of the H3 Polars extension.
 
 - If you know how to make any of these other libraries more performant, please open a PR. I want to be as fair as possible.
 - I'm not an expert in DuckDB, but copying the data should be 0 cost due to Apache Arrow?
-- I used `h3==4.1.2`, `polars==1.8.2` and `duckdb==1.1.3`.
+- The driver prints library and extension versions so saved benchmark output can be reproduced.
 - Attempted to also benchmark H3-Pandas, but project appears to be abandoned and doesn't work with h3 >= 4.0.0.
 """
 
@@ -14,6 +14,7 @@ import statistics
 import time
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
+from importlib.metadata import version
 from pathlib import Path
 from typing import Literal
 
@@ -61,6 +62,7 @@ class BenchmarkResult:
 @dataclass
 class ParamConfig:
     num_iterations: int
+    warmup_iterations: int
     resolution: int
     grid_ring_distance: int
     libraries: list[Library] | Literal["all"] = "all"
@@ -128,6 +130,10 @@ class Benchmark:
         con.execute("INSTALL h3 FROM community;")
         con.execute("LOAD h3;")
         self.con = con
+        self.duckdb_h3_version = con.execute(
+            "SELECT extension_version FROM duckdb_extensions() "
+            "WHERE extension_name = 'h3'"
+        ).fetchone()[0]
 
         self.config = config
 
@@ -283,10 +289,14 @@ class Benchmark:
             for library in libraries:
                 func = config["funcs"][library]
 
+                input_df = df.head(num_rows)
+                for _ in range(self.config.warmup_iterations):
+                    func(input_df)
+
                 perf_times = []
                 for _ in range(self.config.num_iterations):
                     start = time.perf_counter()
-                    result_df = func(df.head(num_rows))
+                    result_df = func(input_df)
                     perf_times.append(time.perf_counter() - start)
 
                 if self.config.verbose:
@@ -451,12 +461,14 @@ class Benchmark:
 
     def _cell_to_parent_plh3(self, df: pl.DataFrame) -> pl.DataFrame:
         return df.with_columns(
-            plh3.cell_to_parent("int_h3_cell", self.config.resolution).alias("result")
+            plh3.cell_to_parent("int_h3_cell", self.config.resolution - 1).alias(
+                "result"
+            )
         )
 
     def _cell_to_parent_duckdb(self, df: pl.DataFrame) -> pl.DataFrame:
         return self.con.execute(
-            f"SELECT h3_cell_to_parent(int_h3_cell, {self.config.resolution}) as result FROM df;"
+            f"SELECT h3_cell_to_parent(int_h3_cell, {self.config.resolution - 1}) as result FROM df;"
         ).pl()
 
     def _cell_to_parent_h3_py(self, df: pl.DataFrame) -> pl.DataFrame:
@@ -464,7 +476,7 @@ class Benchmark:
             pl.struct(["str_h3_cell"])
             .map_elements(
                 lambda row: h3.cell_to_parent(
-                    row["str_h3_cell"], self.config.resolution
+                    row["str_h3_cell"], self.config.resolution - 1
                 ),
                 return_dtype=pl.Utf8,
             )
@@ -682,6 +694,42 @@ def _pretty_print_avg_results(results: list[BenchmarkResult]):
         print(f"{lib:<10} {median_by_lib[lib]:<8} {avg_by_lib[lib]:<8}")
 
 
+def _pretty_print_duckdb_comparison(results: list[BenchmarkResult]) -> None:
+    by_name: dict[str, dict[Library, BenchmarkResult]] = defaultdict(dict)
+    for result in results:
+        by_name[result.name][result.library] = result
+
+    comparisons = [
+        (name, library_results["plh3"], library_results["duckdb"])
+        for name, library_results in by_name.items()
+        if "plh3" in library_results and "duckdb" in library_results
+    ]
+    if not comparisons:
+        return
+
+    print("\n\n======= polars-h3 vs DuckDB H3 =======\n")
+    print(
+        f"{'Function':<21} {'Rows':>8} {'polars-h3':>12} "
+        f"{'DuckDB':>12} {'Speedup':>10}"
+    )
+    print("-" * 69)
+    speedups = []
+    for name, plh3_result, duckdb_result in comparisons:
+        speedup = duckdb_result.avg_seconds / plh3_result.avg_seconds
+        speedups.append(speedup)
+        print(
+            f"{name:<21} {plh3_result.num_rows_human:>8} "
+            f"{plh3_result.avg_seconds * 1_000:>10.2f}ms "
+            f"{duckdb_result.avg_seconds * 1_000:>10.2f}ms "
+            f"{speedup:>9.2f}x"
+        )
+
+    print(
+        f"\nMedian unweighted speedup (DuckDB / polars-h3): "
+        f"{statistics.median(speedups):.2f}x"
+    )
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="h3-bench",
@@ -705,6 +753,12 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--iterations", "-n", type=int, default=3)
     parser.add_argument(
+        "--warmup-iterations",
+        type=int,
+        default=1,
+        help="Warm-up runs per function and library, excluded from measurements",
+    )
+    parser.add_argument(
         "--fast-factor",
         type=int,
         default=1,
@@ -725,6 +779,7 @@ def _build_param_config(args: argparse.Namespace) -> ParamConfig:
         resolution=9,
         grid_ring_distance=3,
         num_iterations=args.iterations,
+        warmup_iterations=max(args.warmup_iterations, 0),
         libraries=args.libraries if "all" not in args.libraries else "all",
         functions=args.functions if "all" not in args.functions else "all",
         difficulty_to_num_rows={
@@ -741,6 +796,12 @@ def main() -> None:
     config = _build_param_config(args)
 
     benchmark = Benchmark(config=config)
+    print("Benchmark versions:")
+    print(f"  polars-h3: {version('polars-h3')}")
+    print(f"  Polars: {pl.__version__}")
+    print(f"  DuckDB: {duckdb.__version__}")
+    print(f"  DuckDB H3 extension: {benchmark.duckdb_h3_version}")
+    print(f"  h3-py: {h3.__version__}")
     results = benchmark.run_all()
 
     last = None
@@ -749,6 +810,8 @@ def main() -> None:
             print(f"\n{r.name} (num_iterations={config.num_iterations})")
             last = r.name
         print(r)
+
+    _pretty_print_duckdb_comparison(results)
 
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-12-05"
+channel = "1.98.0"
 components  = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,1 @@
-group_imports = "StdExternalCrate"
-imports_granularity = "Module"
 match_block_trailing_comma = true

--- a/src/engine/edge.rs
+++ b/src/engine/edge.rs
@@ -162,7 +162,13 @@ pub fn origin_to_directed_edges(cell_series: &Series) -> PolarsResult<Series> {
 
     let edges: Vec<Option<Vec<u64>>> = cells
         .into_par_iter()
-        .map(|cell| cell.map(|idx| idx.edges().map(Into::into).collect()))
+        .map(|cell| {
+            cell.map(|idx| {
+                let mut edges: Vec<_> = idx.edges().map(Into::into).collect();
+                edges.sort_unstable();
+                edges
+            })
+        })
         .collect();
 
     list_u64_vecs_to_series(PlSmallStr::from(""), edges, &DataType::UInt64)

--- a/src/engine/hierarchy.rs
+++ b/src/engine/hierarchy.rs
@@ -167,13 +167,12 @@ pub fn compact_cells(cell_series: &Series) -> PolarsResult<Series> {
                 opt_series
                     .map(|series| {
                         let cells = parse_cell_indices(&series)?;
-                        let cell_vec: Vec<_> = cells.into_iter().flatten().collect();
+                        let mut cell_vec: Vec<_> = cells.into_iter().flatten().collect();
 
-                        CellIndex::compact(cell_vec)
-                            .map_err(|e| {
-                                PolarsError::ComputeError(format!("Compaction error: {}", e).into())
-                            })
-                            .map(|compacted| compacted.into_iter().map(u64::from).collect())
+                        CellIndex::compact(&mut cell_vec).map_err(|e| {
+                            PolarsError::ComputeError(format!("Compaction error: {}", e).into())
+                        })?;
+                        Ok(cell_vec.into_iter().map(u64::from).collect())
                     })
                     .transpose()
             })
@@ -181,12 +180,12 @@ pub fn compact_cells(cell_series: &Series) -> PolarsResult<Series> {
     } else {
         // Input is not a list, so we treat it as a single column of cells.
         let cells = parse_cell_indices(cell_series)?;
-        let cell_vec: Vec<_> = cells.into_iter().flatten().collect();
+        let mut cell_vec: Vec<_> = cells.into_iter().flatten().collect();
 
-        let compacted = CellIndex::compact(cell_vec)
+        CellIndex::compact(&mut cell_vec)
             .map_err(|e| PolarsError::ComputeError(format!("Compaction error: {}", e).into()))?;
 
-        vec![Some(compacted.into_iter().map(u64::from).collect())]
+        vec![Some(cell_vec.into_iter().map(u64::from).collect())]
     };
 
     // Determine the target inner dtype based on the original column

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -86,6 +86,22 @@ def test_origin_to_directed_edges(test_params):
     assert len(df["edges"][0]) == test_params["output_length"]
 
 
+def test_origin_to_directed_edges_preserves_direction_order():
+    df = pl.DataFrame(
+        {"h3_cell": [599686042433355775]},
+        schema={"h3_cell": pl.UInt64},
+    ).with_columns(edges=plh3.origin_to_directed_edges("h3_cell"))
+
+    assert df["edges"][0].to_list() == [
+        1248204388774707199,
+        1320261982812635135,
+        1392319576850563071,
+        1464377170888491007,
+        1536434764926418943,
+        1608492358964346879,
+    ]
+
+
 def test_directed_edge_operations():
     # Test edge to cells conversion
     df = pl.DataFrame(


### PR DESCRIPTION
## Summary

- upgrade h3o from 0.7.1 to 0.11.0
- pin Rust 1.98.0 and update ethnum to its compatible 1.5.3 patch
- adapt `compact_cells` to h3o's in-place compaction API
- preserve historical directed-edge ordering with an exact regression test
- remove two rustfmt settings unsupported by stable Rust
- make cross-library benchmarks more reproducible with version reporting and excluded warmups
- add a direct DuckDB-to-polars-h3 comparison table and correct the parent-resolution workload

## Performance

All 46 internal workloads ran at full configured sizes with three iterations. The final h3o 0.11 figures average two complete runs (six samples total).

- Original end-to-end: 5.809s
- Final end-to-end: 5.205s
- Descriptive aggregate: 1.116x faster
- Compiler-controlled h3o impact: 1.093x faster

| Function | h3o 0.7.1 | h3o 0.11.0 | Speedup |
| --- | ---: | ---: | ---: |
| `cell_area` | 0.687s | 0.314s | **2.19x** |
| `edge_length` | 0.223s | 0.183s | **1.21x** |
| `grid_path_cells` | 0.0210s | 0.0177s | **1.19x** |
| `average_hexagon_area` | 0.0601s | 0.0509s | **1.18x** |
| `cell_to_lat` | 0.114s | 0.098s | **1.17x** |
| `directed_edge_to_boundary` | 0.0845s | 0.0751s | **1.13x** |
| `cell_to_latlng` | 0.142s | 0.128s | **1.12x** |

The controlled run showed `uncompact_cells` 6.5% slower (within its baseline variance) and `cells_to_directed_edge` 5.5% slower. Both remain faster end-to-end than the original Rust 1.85 build.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-features`
- `uv run --no-sync ruff check polars_h3 tests benchmarks`
- `uv run --no-sync ty check polars_h3`
- release Maturin build
- `uv run --no-sync pytest tests` — 198 passed
- all 46 benchmark workloads completed
- `ruff check benchmarks/engine.py`

The cross-library benchmark runtime was not rerun locally because the optional DuckDB dependency is not installed in the active environment.
