### PR TITLE
Release v0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "polars-h3"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "h3o",
  "polars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-h3"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/filimoa/polars-h3"
 
 [project]
 name = "polars-h3"
-version = "0.6.3"
+version = "0.6.4"
 description = "H3 bindings for Polars"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1592,7 +1592,7 @@ wheels = [
 
 [[package]]
 name = "polars-h3"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- bump the Python package, Rust crate, and lockfiles to 0.6.4
- prepare a patch release for the h3o 0.11 upgrade, Zensical documentation migration, and benchmark improvements
- preserve the existing public Python API

## Release highlights

- upgrade h3o from 0.7.1 to 0.11.0, with about 1.12x aggregate improvement across the internal benchmark suite and 2.19x for `cell_area`
- migrate the documentation site to Zensical with a simpler guide/API structure, richer examples, graphing guidance, and `llms.txt`
- add reproducible cross-library benchmarking with version reporting, excluded warmups, corrected parent-resolution inputs, and a direct DuckDB comparison

## Validation

- `make check`
  - Rust and Python formatting
  - Cargo clippy
  - Ruff and ty
  - development extension build
  - 198 tests passed
- `uv lock --check --offline`
- release wheel build
- source distribution build
- verified wheel metadata: `Version: 0.6.4`, `Requires-Python: >=3.9`
- verified source distribution metadata reports 0.6.4

Publishing the GitHub release after this PR merges will trigger the existing multi-platform wheel build and trusted PyPI upload workflow.
