### PR TITLE
Release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "polars-h3"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "geo",
  "geozero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-h3"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/filimoa/polars-h3"
 
 [project]
 name = "polars-h3"
-version = "0.6.4"
+version = "0.7.0"
 description = "H3 bindings for Polars"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2225,7 +2225,7 @@ wheels = [
 
 [[package]]
 name = "polars-h3"
-version = "0.6.4"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- bump the Python package version to 0.7.0
- bump the Rust crate version to 0.7.0
- synchronize Cargo and uv lockfiles

## Dependencies

- #18 is merged
- depends on #21; merge #21, then mark this PR ready and merge it

## Validation

- `make check` on #21 (282 tests passed on Python 3.12)
- clean builds and 282 tests passed on Python 3.11 and Python 3.14
- release diff contains only the four version lines
- `cargo metadata --locked --no-deps --format-version 1`
- `uv lock --check`
- `git diff --check`

## After merge

Publish a GitHub Release tagged `v0.7.0`; the tag-triggered workflow will build platform wheels and the source distribution, then publish them to PyPI.